### PR TITLE
8 set actual data for a stint and have it impact calculation for the rest of the race

### DIFF
--- a/src/app/components/stats/stats.component.spec.ts
+++ b/src/app/components/stats/stats.component.spec.ts
@@ -36,7 +36,10 @@ describe('StatsComponent', () => {
       stintStartTime: undefined,
       timeDriven: undefined,
       timeInPitlane: undefined,
-      totalStintLength: undefined
+      totalStintLength: undefined,
+      actualFuelUsed: undefined,
+      actualLaps: undefined,
+      actualStintEndTime: undefined
     };
 
     component.racePlan = new RacePlanModel(0, [stintModel]);

--- a/src/app/models/stint-model.ts
+++ b/src/app/models/stint-model.ts
@@ -10,4 +10,8 @@ export interface StintModel {
   refuelTime: number | undefined;
   totalStintLength: number | undefined;
   stintEndTime: Date | undefined;
+
+  actualStintEndTime: Date | undefined;
+  actualFuelUsed: number | undefined;
+  actualLaps: number | undefined;
 }

--- a/src/app/pages/stintlab/stintlab.component.html
+++ b/src/app/pages/stintlab/stintlab.component.html
@@ -59,41 +59,62 @@
               />
             </td>
             <td>{{ stint.stintStartTime | date: 'dd.MM.yyyy HH:mm:ss z'}}</td>
-            <td>
-              <p-inputnumber
-                mode="decimal"
-                [useGrouping]="false"
-                [maxFractionDigits]="0"
-                [ngModel]="stint.actualLaps ?? stint.laps"
-                (ngModelChange)="stint.actualLaps = $event"
-                (focusout)="calculateStints()"
-              />
+            <td [pEditableColumn]="stint.actualLaps" pEditableColumnField="actualLaps">
+              <p-cellEditor>
+                    <ng-template #input>
+                      <p-inputnumber
+                        mode="decimal"
+                        [useGrouping]="false"
+                        [maxFractionDigits]="0"
+                        [ngModel]="stint.actualLaps ?? stint.laps"
+                        (ngModelChange)="stint.actualLaps = $event"
+                        (focusout)="calculateStints()"
+                      />
+                    </ng-template>
+                    <ng-template #output>
+                        {{ stint.actualLaps ?? stint.laps }}
+                    </ng-template>
+                  </p-cellEditor>
             </td>
-            <td>
-              <p-inputnumber
-                mode="decimal"
-                [useGrouping]="false"
-                [maxFractionDigits]="3"
-                [ngModel]="stint.actualfuelUsed ?? stint.fuelUsed"
-                (ngModelChange)="stint.actualfuelUsed = $event"
-                (focusout)="calculateStints()"
-              />
+            <td [pEditableColumn]="stint.actualFuelUsed" pEditableColumnField="actualFuelUsed">
+              <p-cellEditor>
+                    <ng-template #input>
+                        <p-inputnumber
+                            mode="decimal"                            
+                            [useGrouping]="false"
+                            [maxFractionDigits]="3"
+                            [ngModel]="stint.actualFuelUsed ?? stint.fuelUsed"
+                            (ngModelChange)="stint.actualFuelUsed = $event"
+                            (focusout)="calculateStints()"
+                            />
+                    </ng-template>
+                    <ng-template #output>
+                        {{ stint.actualFuelUsed ?? stint.fuelUsed }}
+                    </ng-template>
+                </p-cellEditor>
             </td>
             <td>{{ stint.timeDriven | millisToDuration }}</td>
             <td>{{ stint.timeInPitlane | millisToDuration }}</td>
             <td>{{ stint.refuelTime | millisToDuration }}</td>
             <td>{{ stint.totalStintLength | millisToDuration }}</td>
-            <td>
-              <p-datepicker
-                [showTime]="true"
-                hourFormat="24"
-                dateFormat="dd.mm.yy"
-                [showSeconds]="true"
-                [ngModel]="stint.actualStintEndTime ?? stint.stintEndTime | primeDate"
-                (ngModelChange)="stint.actualStintEndTime = $event"
-                (focusout)="calculateStints()"
-                appendTo="body"
-              />
+            <td [pEditableColumn]="stint.actualStintEndTime" pEditableColumnField="actualStintEndTime">
+              <p-cellEditor>
+                    <ng-template #input>
+                      <p-datepicker
+                        [showTime]="true"
+                        hourFormat="24"
+                        dateFormat="dd.mm.yy"
+                        [showSeconds]="true"
+                        [ngModel]="stint.actualStintEndTime ?? stint.stintEndTime | primeDate"
+                        (ngModelChange)="stint.actualStintEndTime = $event"
+                        (focusout)="calculateStints()"
+                        appendTo="body"
+                      />
+                    </ng-template>
+                    <ng-template #output>
+                        {{ (stint.actualStintEndTime ?? stint.stintEndTime) | date: 'dd.MM.yyyy HH:mm:ss z' }}
+                    </ng-template>
+                </p-cellEditor>
             </td>
           </tr>
         </ng-template>

--- a/src/app/pages/stintlab/stintlab.component.html
+++ b/src/app/pages/stintlab/stintlab.component.html
@@ -59,13 +59,42 @@
               />
             </td>
             <td>{{ stint.stintStartTime | date: 'dd.MM.yyyy HH:mm:ss z'}}</td>
-            <td>{{ stint.laps }}</td>
-            <td>{{ stint.fuelUsed | number : "1.0-2" }}</td>
+            <td>
+              <p-inputnumber
+                mode="decimal"
+                [useGrouping]="false"
+                [maxFractionDigits]="0"
+                [ngModel]="stint.actualLaps ?? stint.laps"
+                (ngModelChange)="stint.actualLaps = $event"
+                (focusout)="calculateStints()"
+              />
+            </td>
+            <td>
+              <p-inputnumber
+                mode="decimal"
+                [useGrouping]="false"
+                [maxFractionDigits]="3"
+                [ngModel]="stint.actualfuelUsed ?? stint.fuelUsed"
+                (ngModelChange)="stint.actualfuelUsed = $event"
+                (focusout)="calculateStints()"
+              />
+            </td>
             <td>{{ stint.timeDriven | millisToDuration }}</td>
             <td>{{ stint.timeInPitlane | millisToDuration }}</td>
             <td>{{ stint.refuelTime | millisToDuration }}</td>
             <td>{{ stint.totalStintLength | millisToDuration }}</td>
-            <td>{{ stint.stintEndTime | date: 'dd.MM.yyyy HH:mm:ss z' }}</td>
+            <td>
+              <p-datepicker
+                [showTime]="true"
+                hourFormat="24"
+                dateFormat="dd.mm.yy"
+                [showSeconds]="true"
+                [ngModel]="stint.actualStintEndTime ?? stint.stintEndTime | primeDate"
+                (ngModelChange)="stint.actualStintEndTime = $event"
+                (focusout)="calculateStints()"
+                appendTo="body"
+              />
+            </td>
           </tr>
         </ng-template>
       </p-table>

--- a/src/app/pages/stintlab/stintlab.component.html
+++ b/src/app/pages/stintlab/stintlab.component.html
@@ -1,27 +1,26 @@
 <div class="container">
   <div class="configuration">
-      <p-panel class="race" header="Race">
-        <p class="m-0">
-          <app-racemanager
-            [(race)]="race"
-            (raceChange)="persistAndCalculateStints();"
-          ></app-racemanager>
-        </p>
-      </p-panel>
-      <p-panel class="driver" header="Drivers">
-        <p class="m-0">
-          <app-drivermanager
-            [(drivers)]="drivers"
-            (driversChange)="persistAndCalculateStints()"
-          ></app-drivermanager>
-        </p>
-      </p-panel>
+    <p-panel class="race" header="Race">
+      <p class="m-0">
+        <app-racemanager
+          [(race)]="race"
+          (raceChange)="persistAndCalculateStints()"
+        ></app-racemanager>
+      </p>
+    </p-panel>
+    <p-panel class="driver" header="Drivers">
+      <p class="m-0">
+        <app-drivermanager
+          [(drivers)]="drivers"
+          (driversChange)="persistAndCalculateStints()"
+        ></app-drivermanager>
+      </p>
+    </p-panel>
   </div>
   <div>
     @if(!validState){
-      <p>invalid input data, processing halted</p>
-    }
-    @if (showTable) {
+    <p>invalid input data, processing halted</p>
+    } @if (showTable) {
     <app-stats [drivers]="drivers" [racePlan]="racePlan"></app-stats>
     <p-panel header="Race Plan" [toggleable]="true">
       <p-table
@@ -49,72 +48,84 @@
               <p-select
                 [options]="drivers"
                 [ngModel]="stint.driver.name"
-                (ngModelChange)="
-                  updateDriver($event, stint.counter)
-                "
+                (ngModelChange)="updateDriver($event, stint.counter)"
                 optionLabel="name"
                 placeholder="{{ stint.driver.name }}"
                 class="w-full md:w-56"
                 appendTo="body"
               />
             </td>
-            <td>{{ stint.stintStartTime | date: 'dd.MM.yyyy HH:mm:ss z'}}</td>
-            <td [pEditableColumn]="stint.actualLaps" pEditableColumnField="actualLaps">
+            <td>{{ stint.stintStartTime | date : "dd.MM.yyyy HH:mm:ss z" }}</td>
+            <td
+              [pEditableColumn]="stint.actualLaps"
+              pEditableColumnField="actualLaps"
+            >
               <p-cellEditor>
-                    <ng-template #input>
-                      <p-inputnumber
-                        mode="decimal"
-                        [useGrouping]="false"
-                        [maxFractionDigits]="0"
-                        [ngModel]="stint.actualLaps ?? stint.laps"
-                        (ngModelChange)="stint.actualLaps = $event"
-                        (focusout)="calculateStints()"
-                      />
-                    </ng-template>
-                    <ng-template #output>
-                        {{ stint.actualLaps ?? stint.laps }}
-                    </ng-template>
-                  </p-cellEditor>
+                <ng-template #input>
+                  <p-inputnumber
+                    mode="decimal"
+                    [useGrouping]="false"
+                    [maxFractionDigits]="0"
+                    [ngModel]="stint.actualLaps ?? stint.laps"
+                    (ngModelChange)="stint.actualLaps = $event"
+                    (focusout)="calculateStints()"
+                  />
+                </ng-template>
+                <ng-template #output>
+                  {{ stint.actualLaps ?? stint.laps }}
+                </ng-template>
+              </p-cellEditor>
             </td>
-            <td [pEditableColumn]="stint.actualFuelUsed" pEditableColumnField="actualFuelUsed">
+            <td
+              [pEditableColumn]="stint.actualFuelUsed"
+              pEditableColumnField="actualFuelUsed"
+            >
               <p-cellEditor>
-                    <ng-template #input>
-                        <p-inputnumber
-                            mode="decimal"                            
-                            [useGrouping]="false"
-                            [maxFractionDigits]="3"
-                            [ngModel]="stint.actualFuelUsed ?? stint.fuelUsed"
-                            (ngModelChange)="stint.actualFuelUsed = $event"
-                            (focusout)="calculateStints()"
-                            />
-                    </ng-template>
-                    <ng-template #output>
-                        {{ stint.actualFuelUsed ?? stint.fuelUsed }}
-                    </ng-template>
-                </p-cellEditor>
+                <ng-template #input>
+                  <p-inputnumber
+                    mode="decimal"
+                    [useGrouping]="false"
+                    [maxFractionDigits]="3"
+                    [ngModel]="stint.actualFuelUsed ?? stint.fuelUsed"
+                    (ngModelChange)="stint.actualFuelUsed = $event"
+                    (focusout)="calculateStints()"
+                  />
+                </ng-template>
+                <ng-template #output>
+                  {{ stint.actualFuelUsed ?? stint.fuelUsed }}
+                </ng-template>
+              </p-cellEditor>
             </td>
             <td>{{ stint.timeDriven | millisToDuration }}</td>
             <td>{{ stint.timeInPitlane | millisToDuration }}</td>
             <td>{{ stint.refuelTime | millisToDuration }}</td>
             <td>{{ stint.totalStintLength | millisToDuration }}</td>
-            <td [pEditableColumn]="stint.actualStintEndTime" pEditableColumnField="actualStintEndTime">
+            <td
+              [pEditableColumn]="stint.actualStintEndTime"
+              pEditableColumnField="actualStintEndTime"
+            >
               <p-cellEditor>
-                    <ng-template #input>
-                      <p-datepicker
-                        [showTime]="true"
-                        hourFormat="24"
-                        dateFormat="dd.mm.yy"
-                        [showSeconds]="true"
-                        [ngModel]="stint.actualStintEndTime ?? stint.stintEndTime | primeDate"
-                        (ngModelChange)="stint.actualStintEndTime = $event"
-                        (focusout)="calculateStints()"
-                        appendTo="body"
-                      />
-                    </ng-template>
-                    <ng-template #output>
-                        {{ (stint.actualStintEndTime ?? stint.stintEndTime) | date: 'dd.MM.yyyy HH:mm:ss z' }}
-                    </ng-template>
-                </p-cellEditor>
+                <ng-template #input>
+                  <p-datepicker
+                    [showTime]="true"
+                    hourFormat="24"
+                    dateFormat="dd.mm.yy"
+                    [showSeconds]="true"
+                    [ngModel]="
+                      stint.actualStintEndTime ?? stint.stintEndTime | primeDate
+                    "
+                    (ngModelChange)="stint.actualStintEndTime = $event"
+                    (focusout)="calculateStints()"
+                    appendTo="body"
+                  />
+                </ng-template>
+                <ng-template #output>
+                  {{
+                    stint.actualStintEndTime ?? stint.stintEndTime
+                      | date : "dd.MM.yyyy HH:mm:ss z"
+                  }}
+                </ng-template>
+              </p-cellEditor>
             </td>
           </tr>
         </ng-template>

--- a/src/app/pages/stintlab/stintlab.component.ts
+++ b/src/app/pages/stintlab/stintlab.component.ts
@@ -16,6 +16,9 @@ import { StatsComponent } from "../../components/stats/stats.component";
 import { MillisToDurationPipe } from "../../pipes/millis-to-duration/millis-to-duration.pipe";
 import { DriverModel } from '../../models/driver-model';
 import { RacePlanModel } from '../../models/race-plan-model';
+import { DatePickerModule } from 'primeng/datepicker';
+import { PrimeDatePipe } from '../../pipes/prime-date/prime-date.pipe';
+import { InputNumberModule } from 'primeng/inputnumber';
 
 @Component({
   selector: 'app-stintlab',
@@ -31,7 +34,10 @@ import { RacePlanModel } from '../../models/race-plan-model';
     SelectModule,
     DrivermanagerComponent,
     RacemanagerComponent,
-    StatsComponent
+    StatsComponent,
+    DatePickerModule,
+    PrimeDatePipe,
+    InputNumberModule
 ],
   templateUrl: './stintlab.component.html',
   styleUrl: './stintlab.component.scss'
@@ -158,15 +164,15 @@ export class StintLabComponent implements OnInit {
     this.localStorageServiceService.set<DriverModel[]>(StintLabComponent.DRIVER_STORAGE, this.drivers);
   }
   
-  private calculateStints(){
+  calculateStints(){
     this.validateInputs();
     
     if(this.validState) {
       var driverPerStintList: DriverModel[] = [];
       if(this.racePlan != undefined){
         driverPerStintList = this.racePlan!.stints
-        .filter(d => d.driver != undefined && this.drivers.includes(d.driver))
-        .map(d => d.driver!);
+          .filter(d => d.driver != undefined && this.drivers.includes(d.driver))
+          .map(d => d.driver!);
       }
   
       this.racePlan = this.stintcalculatorService.calculateStints(this.race, this.racePlan, driverPerStintList, this.drivers[0]);

--- a/src/app/pages/stintlab/stintlab.component.ts
+++ b/src/app/pages/stintlab/stintlab.component.ts
@@ -161,8 +161,15 @@ export class StintLabComponent implements OnInit {
   private calculateStints(){
     this.validateInputs();
     
-    if(this.validState) {  
-      this.racePlan = this.stintcalculatorService.calculateStints(this.race, this.racePlan, this.drivers[0]);
+    if(this.validState) {
+      var driverPerStintList: DriverModel[] = [];
+      if(this.racePlan != undefined){
+        driverPerStintList = this.racePlan!.stints
+        .filter(d => d.driver != undefined && this.drivers.includes(d.driver))
+        .map(d => d.driver!);
+      }
+  
+      this.racePlan = this.stintcalculatorService.calculateStints(this.race, this.racePlan, driverPerStintList, this.drivers[0]);
       this.persistPlan();
       this.showTable = true;
     }

--- a/src/app/pages/stintlab/stintlab.component.ts
+++ b/src/app/pages/stintlab/stintlab.component.ts
@@ -182,16 +182,4 @@ export class StintLabComponent implements OnInit {
       this.showTable = true;
     }
   }
-
-  setEndTimeToNow(stint: StintModel) {
-    var current = new Date();
-    if(stint.stintStartTime! <= current) {
-      stint.actualStintEndTime = new Date();
-    }
-  }
-
-  setEndTime(stint: StintModel) {
-    stint.actualStintEndTime = undefined;
-    console.log('A')
-  }
 }

--- a/src/app/pages/stintlab/stintlab.component.ts
+++ b/src/app/pages/stintlab/stintlab.component.ts
@@ -19,11 +19,11 @@ import { RacePlanModel } from '../../models/race-plan-model';
 import { DatePickerModule } from 'primeng/datepicker';
 import { PrimeDatePipe } from '../../pipes/prime-date/prime-date.pipe';
 import { InputNumberModule } from 'primeng/inputnumber';
+import { StintModel } from '../../models/stint-model';
 
 @Component({
   selector: 'app-stintlab',
   imports: [
-    DecimalPipe,
     DatePipe,
     MillisToDurationPipe,
     FormsModule,
@@ -165,6 +165,8 @@ export class StintLabComponent implements OnInit {
   }
   
   calculateStints(){
+    
+    console.log('B')
     this.validateInputs();
     
     if(this.validState) {
@@ -179,5 +181,17 @@ export class StintLabComponent implements OnInit {
       this.persistPlan();
       this.showTable = true;
     }
+  }
+
+  setEndTimeToNow(stint: StintModel) {
+    var current = new Date();
+    if(stint.stintStartTime! <= current) {
+      stint.actualStintEndTime = new Date();
+    }
+  }
+
+  setEndTime(stint: StintModel) {
+    stint.actualStintEndTime = undefined;
+    console.log('A')
   }
 }

--- a/src/app/pages/stintlab/stintlab.component.ts
+++ b/src/app/pages/stintlab/stintlab.component.ts
@@ -165,8 +165,6 @@ export class StintLabComponent implements OnInit {
   }
   
   calculateStints(){
-    
-    console.log('B')
     this.validateInputs();
     
     if(this.validState) {

--- a/src/app/pages/stintlab/stintlab.component.ts
+++ b/src/app/pages/stintlab/stintlab.component.ts
@@ -160,15 +160,9 @@ export class StintLabComponent implements OnInit {
   
   private calculateStints(){
     this.validateInputs();
-    if(this.validState) {
-      var driverPerStintList: DriverModel[] = [];
-      if(this.racePlan != undefined){
-        driverPerStintList = this.racePlan!.stints
-        .filter(d => d.driver != undefined && this.drivers.includes(d.driver))
-        .map(d => d.driver!);
-      }
-  
-      this.racePlan = this.stintcalculatorService.calculateStints(this.race, driverPerStintList, this.drivers[0]);
+    
+    if(this.validState) {  
+      this.racePlan = this.stintcalculatorService.calculateStints(this.race, this.racePlan, this.drivers[0]);
       this.persistPlan();
       this.showTable = true;
     }

--- a/src/app/pipes/prime-date/prime-date.pipe.spec.ts
+++ b/src/app/pipes/prime-date/prime-date.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { PrimeDatePipe } from './prime-date.pipe';
+
+describe('PrimeDatePipe', () => {
+  it('create an instance', () => {
+    const pipe = new PrimeDatePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/prime-date/prime-date.pipe.ts
+++ b/src/app/pipes/prime-date/prime-date.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'primeDate'
+})
+export class PrimeDatePipe implements PipeTransform {
+
+  transform(date: any): Date {
+    return new Date(date);
+  }
+
+}

--- a/src/app/services/stintcalculator/stintcalculator.service.ts
+++ b/src/app/services/stintcalculator/stintcalculator.service.ts
@@ -1,40 +1,66 @@
-import { DriverModel } from '../../models/driver-model';
-import { Injectable } from '@angular/core';
-import { StintModel } from '../../models/stint-model';
-import { RaceModel } from '../../models/race-model';
-import { NGXLogger } from 'ngx-logger';
-import { RacePlanModel } from '../../models/race-plan-model';
+import { DriverModel } from "../../models/driver-model";
+import { Injectable } from "@angular/core";
+import { StintModel } from "../../models/stint-model";
+import { RaceModel } from "../../models/race-model";
+import { NGXLogger } from "ngx-logger";
+import { RacePlanModel } from "../../models/race-plan-model";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: "root",
 })
 export class StintcalculatorService {
+  constructor(private logger: NGXLogger) {}
 
-constructor(private logger: NGXLogger) { }
-
-  calculateStints(race: RaceModel, currentRacePlan: RacePlanModel | undefined, drivers: DriverModel[], defaultDriver: DriverModel) : RacePlanModel {
+  calculateStints(
+    race: RaceModel,
+    currentRacePlan: RacePlanModel | undefined,
+    drivers: DriverModel[],
+    defaultDriver: DriverModel
+  ): RacePlanModel {
     //prepare some calc values
     var stintCounter = 0;
     var stints: StintModel[] = [];
     var stintStartTime: Date = race.raceStart!;
-    var raceEndTime: Date = new Date(race.raceStart!.getTime() + race.raceDurationInMilliseconds!);
+    var raceEndTime: Date = new Date(
+      race.raceStart!.getTime() + race.raceDurationInMilliseconds!
+    );
     // var fullRefillTime: number = Math.ceil(race.fuelTankSizeInLiters! * race.refuelRateInMillisecondsPerLiterRefueled!);
     const refuelTimePerLiter = race.refuelRateInMillisecondsPerLiterRefueled!;
     const fuelTankSize = race.fuelTankSizeInLiters!;
     var fuel = fuelTankSize;
 
     //calculate the first full stint, as the car is filled before the race, no need to calculate time in the pitlane
-    var nextStint = this.getStintModel(currentRacePlan, stintCounter, defaultDriver, drivers, stintStartTime, fuel, fuelTankSize, refuelTimePerLiter, 0);
-    fuel -= nextStint.actualFuelUsed ?? nextStint.fuelUsed!
+    var nextStint = this.getStintModel(
+      currentRacePlan,
+      stintCounter,
+      defaultDriver,
+      drivers,
+      stintStartTime,
+      fuel,
+      fuelTankSize,
+      refuelTimePerLiter,
+      0
+    );
+    fuel -= nextStint.actualFuelUsed ?? nextStint.fuelUsed!;
 
     //check if the last calculated full stint ends before the race does, if so, add it to the plan and calculate another one
-    while(raceEndTime > nextStint.stintEndTime!){
+    while (raceEndTime > nextStint.stintEndTime!) {
       stints.push(nextStint);
 
       stintCounter++;
       stintStartTime = nextStint.stintEndTime!;
-      nextStint = this.getStintModel(currentRacePlan, stintCounter, defaultDriver, drivers, stintStartTime, fuel, fuelTankSize, refuelTimePerLiter, race.driveThroughInMilliseconds!);
-      fuel -= nextStint.actualFuelUsed ?? nextStint.fuelUsed!
+      nextStint = this.getStintModel(
+        currentRacePlan,
+        stintCounter,
+        defaultDriver,
+        drivers,
+        stintStartTime,
+        fuel,
+        fuelTankSize,
+        refuelTimePerLiter,
+        race.driveThroughInMilliseconds!
+      );
+      fuel -= nextStint.actualFuelUsed ?? nextStint.fuelUsed!;
     }
 
     /*
@@ -48,66 +74,101 @@ constructor(private logger: NGXLogger) { }
     do {
       remainingLaps++;
       nextStint.fuelUsed = remainingLaps * nextStint.driver!.fuelConsumption!;
-      nextStint.timeDriven = remainingLaps * nextStint.driver!.laptimeInMilliseconds!;
-      if(stints.length != 0){
-        nextStint.refuelTime = Math.ceil(nextStint.fuelUsed * race.refuelRateInMillisecondsPerLiterRefueled!);
-        nextStint.timeInPitlane = race.driveThroughInMilliseconds! + nextStint.refuelTime;
-      }
-      else{
+      nextStint.timeDriven =
+        remainingLaps * nextStint.driver!.laptimeInMilliseconds!;
+      if (stints.length != 0) {
+        nextStint.refuelTime = Math.ceil(
+          nextStint.fuelUsed * race.refuelRateInMillisecondsPerLiterRefueled!
+        );
+        nextStint.timeInPitlane =
+          race.driveThroughInMilliseconds! + nextStint.refuelTime;
+      } else {
         nextStint.refuelTime = 0;
         nextStint.timeInPitlane = 0;
       }
-      nextStint.totalStintLength = nextStint.timeDriven + nextStint.timeInPitlane;
-      nextStint.stintEndTime = new Date(stintStartTime.getTime() + nextStint.timeDriven);
-    }
-    while(raceEndTime > nextStint.stintEndTime);
+      nextStint.totalStintLength =
+        nextStint.timeDriven + nextStint.timeInPitlane;
+      nextStint.stintEndTime = new Date(
+        stintStartTime.getTime() + nextStint.timeDriven
+      );
+    } while (raceEndTime > nextStint.stintEndTime);
 
     stints.push(nextStint);
     var totalLaps = (stintCounter - 1) * nextStint.laps! + remainingLaps;
     return new RacePlanModel(totalLaps, stints);
   }
 
-
-  private getStintModel(currentRacePlan: RacePlanModel | undefined, stintCounter: number, defaultDriver: DriverModel, drivers: DriverModel[], stintStartTime: Date, fuel: number, tankSize: number, refuelTimePerLiter: number, timeToPassPitlane: number) : StintModel {
-    var refuelTime = (tankSize - fuel) * refuelTimePerLiter;
+  private getStintModel(
+    currentRacePlan: RacePlanModel | undefined,
+    stintCounter: number,
+    defaultDriver: DriverModel,
+    drivers: DriverModel[],
+    stintStartTime: Date,
+    fuel: number,
+    tankSize: number,
+    refuelTimePerLiter: number,
+    timeToPassPitlane: number
+  ): StintModel {
+    var refuelTime = Math.floor((tankSize - fuel) * refuelTimePerLiter);
     var driver = this.getOrDefault(drivers, stintCounter, defaultDriver);
-    var lapsInFullStint = this.getFromRaceplan(currentRacePlan, rp => rp.stints[stintCounter]?.actualLaps, Math.floor(tankSize / driver.fuelConsumption!));
+    var lapsInFullStint = this.getFromRaceplan(
+      currentRacePlan,
+      (rp) => rp.stints[stintCounter]?.actualLaps,
+      Math.floor(tankSize / driver.fuelConsumption!)
+    );
     var timeDriven = lapsInFullStint.value * driver.laptimeInMilliseconds!;
 
-    var fuelUsed = this.getFromRaceplan(currentRacePlan, rp => rp.stints[stintCounter]?.actualFuelUsed, lapsInFullStint.value * driver.fuelConsumption!);
-    
-    var stintEndTime = this.getFromRaceplan<Date>(currentRacePlan, (rp) => rp.stints[stintCounter]?.actualStintEndTime, new Date(stintStartTime.getTime() + timeDriven));
-    if(stintEndTime.accessed) {
-      timeDriven = stintEndTime.accessed.getTime() - stintStartTime.getTime() - timeToPassPitlane - refuelTime;
+    var fuelUsed = this.getFromRaceplan(
+      currentRacePlan,
+      (rp) => rp.stints[stintCounter]?.actualFuelUsed,
+      lapsInFullStint.value * driver.fuelConsumption!
+    );
+
+    var stintEndTime = this.getFromRaceplan<Date>(
+      currentRacePlan,
+      (rp) => rp.stints[stintCounter]?.actualStintEndTime,
+      new Date(stintStartTime.getTime() + timeDriven)
+    );
+    if (stintEndTime.accessed) {
+      timeDriven = Math.floor(
+        stintEndTime.accessed.getTime() -
+          stintStartTime.getTime() -
+          timeToPassPitlane -
+          refuelTime
+      );
     }
 
     return {
-        counter: stintCounter,
-        driver: driver,
-        laps: lapsInFullStint.value,
-        stintStartTime: stintStartTime,
-        stintEndTime: stintEndTime.value,
-        fuelUsed: fuelUsed.value,
-        timeInPitlane: timeToPassPitlane + refuelTime,
-        refuelTime: refuelTime,
-        timeDriven: timeDriven,
-        totalStintLength: timeDriven + timeToPassPitlane + refuelTime,
-        actualFuelUsed: fuelUsed.accessed,
-        actualLaps: lapsInFullStint.accessed,
-        actualStintEndTime: stintEndTime.accessed
-      };
+      counter: stintCounter,
+      driver: driver,
+      laps: lapsInFullStint.value,
+      stintStartTime: stintStartTime,
+      stintEndTime: stintEndTime.value,
+      fuelUsed: fuelUsed.value,
+      timeInPitlane: timeToPassPitlane + refuelTime,
+      refuelTime: refuelTime,
+      timeDriven: timeDriven,
+      totalStintLength: timeDriven + timeToPassPitlane + refuelTime,
+      actualFuelUsed: fuelUsed.accessed,
+      actualLaps: lapsInFullStint.accessed,
+      actualStintEndTime: stintEndTime.accessed,
+    };
   }
 
-  private getFromRaceplan<T>(racePlan: RacePlanModel | undefined, accessor: (rp: RacePlanModel) => T | undefined, fallback: T) : { value: T, accessed: T | undefined } {
-    if(!racePlan){
-      return {value: fallback, accessed: undefined}
+  private getFromRaceplan<T>(
+    racePlan: RacePlanModel | undefined,
+    accessor: (rp: RacePlanModel) => T | undefined,
+    fallback: T
+  ): { value: T; accessed: T | undefined } {
+    if (!racePlan) {
+      return { value: fallback, accessed: undefined };
     }
     var accessed = accessor(racePlan);
-    return {value: accessed ?? fallback, accessed: accessed}
+    return { value: accessed ?? fallback, accessed: accessed };
   }
 
-   private getOrDefault<T>(array: T[], index: number, fallback: T) : T {
-    if(array.length > index){
+  private getOrDefault<T>(array: T[], index: number, fallback: T): T {
+    if (array.length > index) {
       return array[index];
     }
     return fallback;

--- a/src/app/services/stintcalculator/stintcalculator.service.ts
+++ b/src/app/services/stintcalculator/stintcalculator.service.ts
@@ -93,7 +93,7 @@ constructor(private logger: NGXLogger) { }
       return {value: fallback, accessed: undefined}
     }
     var accessed = accessor(racePlan);
-    return {value: accessed ?? fallback, accessed: undefined}
+    return {value: accessed ?? fallback, accessed: accessed}
   }
 
    private getOrDefault<T>(array: T[], index: number, fallback: T) : T {

--- a/src/app/services/stintcalculator/stintcalculator.service.ts
+++ b/src/app/services/stintcalculator/stintcalculator.service.ts
@@ -18,10 +18,14 @@ constructor(private logger: NGXLogger) { }
     var stints: StintModel[] = [];
     var stintStartTime: Date = race.raceStart!;
     var raceEndTime: Date = new Date(race.raceStart!.getTime() + race.raceDurationInMilliseconds!);
-    var fullRefillTime: number = Math.ceil(race.fuelTankSizeInLiters! * race.refuelRateInMillisecondsPerLiterRefueled!);
+    // var fullRefillTime: number = Math.ceil(race.fuelTankSizeInLiters! * race.refuelRateInMillisecondsPerLiterRefueled!);
+    const refuelTimePerLiter = race.refuelRateInMillisecondsPerLiterRefueled!;
+    const fuelTankSize = race.fuelTankSizeInLiters!;
+    var fuel = fuelTankSize;
 
     //calculate the first full stint, as the car is filled before the race, no need to calculate time in the pitlane
-    var nextStint = this.getStintModel(currentRacePlan, stintCounter, defaultDriver, race, drivers, stintStartTime, 0, 0);
+    var nextStint = this.getStintModel(currentRacePlan, stintCounter, defaultDriver, drivers, stintStartTime, fuel, fuelTankSize, refuelTimePerLiter, 0);
+    fuel -= nextStint.actualFuelUsed ?? nextStint.fuelUsed!
 
     //check if the last calculated full stint ends before the race does, if so, add it to the plan and calculate another one
     while(raceEndTime > nextStint.stintEndTime!){
@@ -29,7 +33,8 @@ constructor(private logger: NGXLogger) { }
 
       stintCounter++;
       stintStartTime = nextStint.stintEndTime!;
-      nextStint = this.getStintModel(currentRacePlan, stintCounter, defaultDriver, race, drivers, stintStartTime, fullRefillTime, race.driveThroughInMilliseconds! + fullRefillTime);
+      nextStint = this.getStintModel(currentRacePlan, stintCounter, defaultDriver, drivers, stintStartTime, fuel, fuelTankSize, refuelTimePerLiter, race.driveThroughInMilliseconds!);
+      fuel -= nextStint.actualFuelUsed ?? nextStint.fuelUsed!
     }
 
     /*
@@ -63,13 +68,18 @@ constructor(private logger: NGXLogger) { }
   }
 
 
-  private getStintModel(currentRacePlan: RacePlanModel | undefined, stintCounter: number, defaultDriver: DriverModel, race: RaceModel, drivers: DriverModel[], stintStartTime: Date, refuelTime: number, timeToPassPitlane: number) : StintModel {
+  private getStintModel(currentRacePlan: RacePlanModel | undefined, stintCounter: number, defaultDriver: DriverModel, drivers: DriverModel[], stintStartTime: Date, fuel: number, tankSize: number, refuelTimePerLiter: number, timeToPassPitlane: number) : StintModel {
+    var refuelTime = (tankSize - fuel) * refuelTimePerLiter;
     var driver = this.getOrDefault(drivers, stintCounter, defaultDriver);
-    var lapsInFullStint = this.getFromRaceplan(currentRacePlan, rp => rp.stints[stintCounter]?.actualLaps, Math.floor(race.fuelTankSizeInLiters! / driver.fuelConsumption!));
+    var lapsInFullStint = this.getFromRaceplan(currentRacePlan, rp => rp.stints[stintCounter]?.actualLaps, Math.floor(tankSize / driver.fuelConsumption!));
     var timeDriven = lapsInFullStint.value * driver.laptimeInMilliseconds!;
-
-    var stintEndTime = this.getFromRaceplan<Date>(currentRacePlan, (rp) => rp.stints[stintCounter]?.actualStintEndTime, new Date(stintStartTime.getTime() + timeDriven));
+    
     var fuelUsed = this.getFromRaceplan(currentRacePlan, rp => rp.stints[stintCounter]?.actualFuelUsed, lapsInFullStint.value * driver.fuelConsumption!);
+    
+    var stintEndTime = this.getFromRaceplan<Date>(currentRacePlan, (rp) => rp.stints[stintCounter]?.actualStintEndTime, new Date(stintStartTime.getTime() + timeDriven));
+    if(stintEndTime.accessed) {
+      timeDriven = stintEndTime.accessed.getTime() - stintStartTime.getTime();
+    }
 
     return {
         counter: stintCounter,

--- a/src/app/services/stintcalculator/stintcalculator.service.ts
+++ b/src/app/services/stintcalculator/stintcalculator.service.ts
@@ -30,7 +30,7 @@ export class StintcalculatorService {
     var fuel = fuelTankSize;
 
     //calculate the first full stint, as the car is filled before the race, no need to calculate time in the pitlane
-    var nextStint = this.getStintModel(
+    var nextStint = this.recalculateNextStint(
       currentRacePlan,
       stintCounter,
       defaultDriver,
@@ -49,7 +49,7 @@ export class StintcalculatorService {
 
       stintCounter++;
       stintStartTime = nextStint.stintEndTime!;
-      nextStint = this.getStintModel(
+      nextStint = this.recalculateNextStint(
         currentRacePlan,
         stintCounter,
         defaultDriver,
@@ -98,7 +98,7 @@ export class StintcalculatorService {
     return new RacePlanModel(totalLaps, stints);
   }
 
-  private getStintModel(
+  private recalculateNextStint(
     currentRacePlan: RacePlanModel | undefined,
     stintCounter: number,
     defaultDriver: DriverModel,

--- a/src/app/services/stintcalculator/stintcalculator.service.ts
+++ b/src/app/services/stintcalculator/stintcalculator.service.ts
@@ -73,12 +73,12 @@ constructor(private logger: NGXLogger) { }
     var driver = this.getOrDefault(drivers, stintCounter, defaultDriver);
     var lapsInFullStint = this.getFromRaceplan(currentRacePlan, rp => rp.stints[stintCounter]?.actualLaps, Math.floor(tankSize / driver.fuelConsumption!));
     var timeDriven = lapsInFullStint.value * driver.laptimeInMilliseconds!;
-    
+
     var fuelUsed = this.getFromRaceplan(currentRacePlan, rp => rp.stints[stintCounter]?.actualFuelUsed, lapsInFullStint.value * driver.fuelConsumption!);
     
     var stintEndTime = this.getFromRaceplan<Date>(currentRacePlan, (rp) => rp.stints[stintCounter]?.actualStintEndTime, new Date(stintStartTime.getTime() + timeDriven));
     if(stintEndTime.accessed) {
-      timeDriven = stintEndTime.accessed.getTime() - stintStartTime.getTime();
+      timeDriven = stintEndTime.accessed.getTime() - stintStartTime.getTime() - timeToPassPitlane - refuelTime;
     }
 
     return {

--- a/src/app/util/duration-util.ts
+++ b/src/app/util/duration-util.ts
@@ -21,7 +21,7 @@ export class DurationUtil {
 
   static fromMilliseconds(millis: number) : DurationUtil {
     var t = new DurationUtil();
-    t.milliseconds = millis % 1000;
+    t.milliseconds = Math.floor(millis % 1000);
     var remainder = Math.floor(millis / 1000);
     t.seconds = remainder % 60;
     remainder = Math.floor(remainder / 60);
@@ -67,9 +67,5 @@ export class DurationUtil {
       result += '.' + formatNumber(this.milliseconds, 'en-US', '3.0');
     }
     return result;
-  }
-
-  static formatNumber(value: number, leadingZeros: number) : string {
-    return ('' + value).padStart(leadingZeros, '0');
   }
 }


### PR DESCRIPTION
Added proper overwrite for fuelUsed, lapsDriven and stintEndTime.

Based on these values other values are calculated as follows (if not overwritten themself):
  - fuelUsed: **lapsDriven** * \<avg fuel usage of driver\>
  - refuelTime: not directly for current stint. But based on actual **fuelUsed** from prevoius stint
  - timeDriven: **stintEndTime** - stintStartTime